### PR TITLE
Update script to support installing Scoop as administrator

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ iwr -useb 'https://raw.githubusercontent.com/scayssials/scoomander/master/bin/in
 iwr -useb 'https://raw.githubusercontent.com/scayssials/scoomander/master/bin/install-scoomander.ps1' | iex; Install -NoPrompt -DefaultScoopTarget C:\some-path
 ```
 
+Installation under the administrator console has been disabled by default for security considerations.
+If you know what you are doing and want to install as administrator you can add the `-RunAsAdmin` flag on the `Install` command.
+
 Once installed, run `scoomander help` for instructions.
 
 The default Scoop setup is configured so all user installed programs Scoop and Scoomander itself live in `C:\Users\<user>\scoop`.

--- a/bin/install-scoomander.ps1
+++ b/bin/install-scoomander.ps1
@@ -4,7 +4,9 @@ new-module -name Install-Scoomander -scriptblock {
             [String]
             $defaultScoopTarget = "$env:USERPROFILE\scoop",
             [Switch]
-            $noPrompt
+            $noPrompt,
+            [Switch]
+            $RunAsAdmin
         )
 
         $changeExecutionPolicy = (Get-ExecutionPolicy) -gt 'RemoteSigned' -or (Get-ExecutionPolicy) -eq 'ByPass'
@@ -38,7 +40,13 @@ new-module -name Install-Scoomander -scriptblock {
         if ($changeExecutionPolicy) {
             Set-ExecutionPolicy RemoteSigned -scope CurrentUser -Force
         }
-        iwr -useb get.scoop.sh | iex
+        if ($RunAsAdmin) {
+            iwr get.scoop.sh -outfile 'scoop-install.ps1'
+            .\scoop-install.ps1 -RunAsAdmin
+            Remove-Item .\scoop-install.ps1
+        } else {
+            iwr -useb get.scoop.sh | iex
+        }
 
         scoop install git
 


### PR DESCRIPTION
By default, Scoop installation is disabled in an administrator console, see [their documention](https://github.com/ScoopInstaller/Install#for-admin).

This pull request adds a `-RunAsAdmin` flag which is then passed to Scoop itself